### PR TITLE
Updates for latest changes to 3.4 grammar.

### DIFF
--- a/Grammar.html
+++ b/Grammar.html
@@ -11,13 +11,13 @@ non-terminal appearing on the right hand side of a production is a link to the
 production for that non-terminal. This grammar is identical to that in the
 Modelica 3.4 specification except for removal of some unnecessary
 parentheses, grouping of some common terms, and reformatting for easier
-readability. The following typographic conventions are used:
+readability. The following typographic conventions are used:</p>
 <ul>
 <li>Keywords are set in <b>boldface</b>.</li>
 <li>Literals other than keywords are <font color="green">"</font><tt>quoted-monospaced</tt><font color="green">"</font> text.</li>
 <li>Non-terminals are set in <i>italics</i>, with <font color="#003399"><i>blue italics</i></font> used for links.</li>
 <li>EBNF meta-characters are <font color="green">green</font>.</li>
-</ul></p>
+</ul>
 <h2>Stored Definition</h2>
 <p><a name="stored_definition" class=NAME><i>stored_definition</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>within</b><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#name" class=HREF><i>name</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>final</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#class_definition" class=HREF><i>class_definition</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font>

--- a/Grammar.html
+++ b/Grammar.html
@@ -17,45 +17,59 @@ readability. The following typographic conventions are used:
 <li>Literals other than keywords are <font color="green">"</font><tt>quoted-monospaced</tt><font color="green">"</font> text.</li>
 <li>Non-terminals are set in <i>italics</i>, with <font color="#003399"><i>blue italics</i></font> used for links.</li>
 <li>EBNF meta-characters are <font color="green">green</font>.</li>
-</ul>
+</ul></p>
 <h2>Stored Definition</h2>
 <p><a name="stored_definition" class=NAME><i>stored_definition</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>within</b><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#name" class=HREF><i>name</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>final</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#class_definition" class=HREF><i>class_definition</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <h2>Class Definition</h2>
 <p><a name="class_definition" class=NAME><i>class_definition</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>encapsulated</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#class_prefixes" class=HREF><i>class_prefixes</i></a><tt>&nbsp;</tt><a href="#class_specifier" class=HREF><i>class_specifier</i></a>
+</p>
 <p><a name="class_prefixes" class=NAME><i>class_prefixes</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>partial</b><tt>&nbsp;</tt><font color=green size="+1">]</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><b>class</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>model</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>operator</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><b>record</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>block</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>expandable</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><b>connector</b>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>type</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>package</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>pure</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>impure</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>operator</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><b>function</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>operator</b><tt>&nbsp;</tt><font color=green size="+1">)</font>
+</p>
 <p><a name="class_specifier" class=NAME><i>class_specifier</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#long_class_specifier" class=HREF><i>long_class_specifier</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#short_class_specifier" class=HREF><i>short_class_specifier</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#der_class_specifier" class=HREF><i>der_class_specifier</i></a>
+</p>
 <p><a name="long_class_specifier" class=NAME><i>long_class_specifier</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><a href="#string_comment" class=HREF><i>string_comment</i></a><tt>&nbsp;</tt><a href="#composition" class=HREF><i>composition</i></a><tt>&nbsp;</tt><b>end</b><tt>&nbsp;</tt><i>IDENT</i>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>extends</b><tt>&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#class_modification" class=HREF><i>class_modification</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#string_comment" class=HREF><i>string_comment</i></a><tt>&nbsp;</tt><a href="#composition" class=HREF><i>composition</i></a><tt>&nbsp;</tt><b>end</b><tt>&nbsp;</tt><i>IDENT</i>
+</p>
 <p><a name="short_class_specifier" class=NAME><i>short_class_specifier</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green>"</font><tt>=</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#base_prefix" class=HREF><i>base_prefix</i></a><tt>&nbsp;</tt><a href="#type_specifier" class=HREF><i>type_specifier</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#array_subscripts" class=HREF><i>array_subscripts</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#class_modification" class=HREF><i>class_modification</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#comment" class=HREF><i>comment</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green>"</font><tt>=</tt><font color=green>"</font><tt>&nbsp;</tt><b>enumeration</b><tt>&nbsp;</tt><font color=green>"</font><tt>(</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#enum_list" class=HREF><i>enum_list</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>:</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">)</font><tt>&nbsp;</tt><font color=green>"</font><tt>)</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#comment" class=HREF><i>comment</i></a>
+</p>
 <p><a name="der_class_specifier" class=NAME><i>der_class_specifier</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green>"</font><tt>=</tt><font color=green>"</font><tt>&nbsp;</tt><b>der</b><tt>&nbsp;</tt><font color=green>"</font><tt>(</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#type_specifier" class=HREF><i>type_specifier</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><font color=green>"</font><tt>)</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#comment" class=HREF><i>comment</i></a>
+</p>
 <p><a name="base_prefix" class=NAME><i>base_prefix</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>input</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>output</b><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="enum_list" class=NAME><i>enum_list</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#enumeration_literal" class=HREF><i>enumeration_literal</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#enumeration_literal" class=HREF><i>enumeration_literal</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="enumeration_literal" class=NAME><i>enumeration_literal</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><a href="#comment" class=HREF><i>comment</i></a>
+</p>
 <p><a name="composition" class=NAME><i>composition</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#element_list" class=HREF><i>element_list</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><b>public</b><tt>&nbsp;</tt><a href="#element_list" class=HREF><i>element_list</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>protected</b><tt>&nbsp;</tt><a href="#element_list" class=HREF><i>element_list</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#equation_section" class=HREF><i>equation_section</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#algorithm_section" class=HREF><i>algorithm_section</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>external</b><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#language_specification" class=HREF><i>language_specification</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
-<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#external_function_call" class=HREF><i>external_function_call</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#annotation" class=HREF><i>annotation</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">]</font>
-<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#annotation" class=HREF><i>annotation</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">]</font>
+<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#external_function_call" class=HREF><i>external_function_call</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#annotation_comment" class=HREF><i>annotation_comment</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">]</font>
+<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#annotation_comment" class=HREF><i>annotation_comment</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="language_specification" class=NAME><i>language_specification</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>STRING</i>
+</p>
 <p><a name="external_function_call" class=NAME><i>external_function_call</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#component_reference" class=HREF><i>component_reference</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>=</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green>"</font><tt>(</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#expression_list" class=HREF><i>expression_list</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green>"</font><tt>)</tt><font color=green>"</font>
+</p>
 <p><a name="element_list" class=NAME><i>element_list</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#element" class=HREF><i>element</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="element" class=NAME><i>element</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#import_clause" class=HREF><i>import_clause</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#extends_clause" class=HREF><i>extends_clause</i></a>
@@ -64,60 +78,84 @@ readability. The following typographic conventions are used:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#component_clause" class=HREF><i>component_clause</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>replaceable</b><tt>&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><a href="#class_definition" class=HREF><i>class_definition</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#component_clause" class=HREF><i>component_clause</i></a><tt>&nbsp;</tt><font color=green size="+1">)</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#constraining_clause" class=HREF><i>constraining_clause</i></a><tt>&nbsp;</tt><a href="#comment" class=HREF><i>comment</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">)</font>
+</p>
 <p><a name="import_clause" class=NAME><i>import_clause</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>import</b><tt>&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green>"</font><tt>=</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#name" class=HREF><i>name</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#name" class=HREF><i>name</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>.</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green>"</font><tt>*</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>.*</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>{</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#import_list" class=HREF><i>import_list</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>}</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">)</font><tt>&nbsp;</tt><a href="#comment" class=HREF><i>comment</i></a>
+</p>
 <p><a name="import_list" class=NAME><i>import_list</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <h2>Extends</h2>
 <p><a name="extends_clause" class=NAME><i>extends_clause</i></a>:
-<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>extends</b><tt>&nbsp;</tt><a href="#type_specifier" class=HREF><i>type_specifier</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#class_modification" class=HREF><i>class_modification</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#annotation" class=HREF><i>annotation</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>extends</b><tt>&nbsp;</tt><a href="#type_specifier" class=HREF><i>type_specifier</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#class_modification" class=HREF><i>class_modification</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#annotation_comment" class=HREF><i>annotation_comment</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="constraining_clause" class=NAME><i>constraining_clause</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>constrainedby</b><tt>&nbsp;</tt><a href="#type_specifier" class=HREF><i>type_specifier</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#class_modification" class=HREF><i>class_modification</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <h2>Component Clause</h2>
 <p><a name="component_clause" class=NAME><i>component_clause</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#type_prefix" class=HREF><i>type_prefix</i></a><tt>&nbsp;</tt><a href="#type_specifier" class=HREF><i>type_specifier</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#array_subscripts" class=HREF><i>array_subscripts</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#component_list" class=HREF><i>component_list</i></a>
+</p>
 <p><a name="type_prefix" class=NAME><i>type_prefix</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>flow</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>stream</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>discrete</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>parameter</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>constant</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>input</b><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>output</b><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="component_list" class=NAME><i>component_list</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#component_declaration" class=HREF><i>component_declaration</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#component_declaration" class=HREF><i>component_declaration</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="component_declaration" class=NAME><i>component_declaration</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#declaration" class=HREF><i>declaration</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#condition_attribute" class=HREF><i>condition_attribute</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#comment" class=HREF><i>comment</i></a>
+</p>
 <p><a name="condition_attribute" class=NAME><i>condition_attribute</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>if</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a>
+</p>
 <p><a name="declaration" class=NAME><i>declaration</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#array_subscripts" class=HREF><i>array_subscripts</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#modification" class=HREF><i>modification</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <h2>Modification</h2>
 <p><a name="modification" class=NAME><i>modification</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#class_modification" class=HREF><i>class_modification</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>=</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>=</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>:=</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a>
+</p>
 <p><a name="class_modification" class=NAME><i>class_modification</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green>"</font><tt>(</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#argument_list" class=HREF><i>argument_list</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green>"</font><tt>)</tt><font color=green>"</font>
+</p>
 <p><a name="argument_list" class=NAME><i>argument_list</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#argument" class=HREF><i>argument</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#argument" class=HREF><i>argument</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="argument" class=NAME><i>argument</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#element_modification_or_replaceable" class=HREF><i>element_modification_or_replaceable</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#element_redeclaration" class=HREF><i>element_redeclaration</i></a>
+</p>
 <p><a name="element_modification_or_replaceable" class=NAME><i>element_modification_or_replaceable</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>each</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>final</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><a href="#element_modification" class=HREF><i>element_modification</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#element_replaceable" class=HREF><i>element_replaceable</i></a><tt>&nbsp;</tt><font color=green size="+1">)</font>
+</p>
 <p><a name="element_modification" class=NAME><i>element_modification</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#name" class=HREF><i>name</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#modification" class=HREF><i>modification</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#string_comment" class=HREF><i>string_comment</i></a>
+</p>
 <p><a name="element_redeclaration" class=NAME><i>element_redeclaration</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>redeclare</b><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>each</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>final</b><tt>&nbsp;</tt><font color=green size="+1">]</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><a href="#short_class_definition" class=HREF><i>short_class_definition</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#component_clause1" class=HREF><i>component_clause1</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#element_replaceable" class=HREF><i>element_replaceable</i></a><tt>&nbsp;</tt><font color=green size="+1">)</font>
+</p>
 <p><a name="element_replaceable" class=NAME><i>element_replaceable</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>replaceable</b><tt>&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><a href="#short_class_definition" class=HREF><i>short_class_definition</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#component_clause1" class=HREF><i>component_clause1</i></a><tt>&nbsp;</tt><font color=green size="+1">)</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#constraining_clause" class=HREF><i>constraining_clause</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="component_clause1" class=NAME><i>component_clause1</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#type_prefix" class=HREF><i>type_prefix</i></a><tt>&nbsp;</tt><a href="#type_specifier" class=HREF><i>type_specifier</i></a><tt>&nbsp;</tt><a href="#component_declaration1" class=HREF><i>component_declaration1</i></a>
+</p>
 <p><a name="component_declaration1" class=NAME><i>component_declaration1</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#declaration" class=HREF><i>declaration</i></a><tt>&nbsp;</tt><a href="#comment" class=HREF><i>comment</i></a>
+</p>
 <p><a name="short_class_definition" class=NAME><i>short_class_definition</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#class_prefixes" class=HREF><i>class_prefixes</i></a><tt>&nbsp;</tt><a href="#short_class_specifier" class=HREF><i>short_class_specifier</i></a>
+</p>
 <h2>Equation</h2>
 <p><a name="equation_section" class=NAME><i>equation_section</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>initial</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><b>equation</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#equation" class=HREF><i>equation</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="algorithm_section" class=NAME><i>algorithm_section</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>initial</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><b>algorithm</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#statement" class=HREF><i>statement</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="equation" class=NAME><i>equation</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><a href="#simple_expression" class=HREF><i>simple_expression</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>=</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#if_equation" class=HREF><i>if_equation</i></a>
@@ -125,6 +163,7 @@ readability. The following typographic conventions are used:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#connect_clause" class=HREF><i>connect_clause</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#when_equation" class=HREF><i>when_equation</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#component_reference" class=HREF><i>component_reference</i></a><tt>&nbsp;</tt><a href="#function_call_args" class=HREF><i>function_call_args</i></a><tt>&nbsp;</tt><font color=green size="+1">)</font><tt>&nbsp;</tt><a href="#comment" class=HREF><i>comment</i></a>
+</p>
 <p><a name="statement" class=NAME><i>statement</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><a href="#component_reference" class=HREF><i>component_reference</i></a><tt>&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><font color=green>"</font><tt>:=</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#function_call_args" class=HREF><i>function_call_args</i></a><tt>&nbsp;</tt><font color=green size="+1">)</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>(</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#output_expression_list" class=HREF><i>output_expression_list</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>)</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green>"</font><tt>:=</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#component_reference" class=HREF><i>component_reference</i></a><tt>&nbsp;</tt><a href="#function_call_args" class=HREF><i>function_call_args</i></a>
@@ -134,64 +173,87 @@ readability. The following typographic conventions are used:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#for_statement" class=HREF><i>for_statement</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#while_statement" class=HREF><i>while_statement</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#when_statement" class=HREF><i>when_statement</i></a><tt>&nbsp;</tt><font color=green size="+1">)</font><tt>&nbsp;</tt><a href="#comment" class=HREF><i>comment</i></a>
+</p>
 <p><a name="if_equation" class=NAME><i>if_equation</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>if</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>then</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#equation" class=HREF><i>equation</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><b>elseif</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>then</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#equation" class=HREF><i>equation</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>else</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#equation" class=HREF><i>equation</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><font color=green size="+1">]</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>end</b><tt>&nbsp;</tt><b>if</b>
+</p>
 <p><a name="if_statement" class=NAME><i>if_statement</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>if</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>then</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#statement" class=HREF><i>statement</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><b>elseif</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>then</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#statement" class=HREF><i>statement</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>else</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#statement" class=HREF><i>statement</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><font color=green size="+1">]</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>end</b><tt>&nbsp;</tt><b>if</b>
+</p>
 <p><a name="for_equation" class=NAME><i>for_equation</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>for</b><tt>&nbsp;</tt><a href="#for_indices" class=HREF><i>for_indices</i></a><tt>&nbsp;</tt><b>loop</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#equation" class=HREF><i>equation</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><b>end</b><tt>&nbsp;</tt><b>for</b>
+</p>
 <p><a name="for_statement" class=NAME><i>for_statement</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>for</b><tt>&nbsp;</tt><a href="#for_indices" class=HREF><i>for_indices</i></a><tt>&nbsp;</tt><b>loop</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#statement" class=HREF><i>statement</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><b>end</b><tt>&nbsp;</tt><b>for</b>
+</p>
 <p><a name="for_indices" class=NAME><i>for_indices</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#for_index" class=HREF><i>for_index</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#for_index" class=HREF><i>for_index</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="for_index" class=NAME><i>for_index</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>in</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="while_statement" class=NAME><i>while_statement</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>while</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>loop</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#statement" class=HREF><i>statement</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><b>end</b><tt>&nbsp;</tt><b>while</b>
+</p>
 <p><a name="when_equation" class=NAME><i>when_equation</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>when</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>then</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#equation" class=HREF><i>equation</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><b>elsewhen</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>then</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#equation" class=HREF><i>equation</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>end</b><tt>&nbsp;</tt><b>when</b>
+</p>
 <p><a name="when_statement" class=NAME><i>when_statement</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>when</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>then</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#statement" class=HREF><i>statement</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><b>elsewhen</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>then</b><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#statement" class=HREF><i>statement</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>end</b><tt>&nbsp;</tt><b>when</b>
+</p>
 <p><a name="connect_clause" class=NAME><i>connect_clause</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>connect</b><tt>&nbsp;</tt><font color=green>"</font><tt>(</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#component_reference" class=HREF><i>component_reference</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#component_reference" class=HREF><i>component_reference</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>)</tt><font color=green>"</font>
+</p>
 <h2>Expression</h2>
 <p><a name="expression" class=NAME><i>expression</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#simple_expression" class=HREF><i>simple_expression</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>if</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>then</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><b>elseif</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><b>then</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>else</b><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a>
+</p>
 <p><a name="simple_expression" class=NAME><i>simple_expression</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#logical_expression" class=HREF><i>logical_expression</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>:</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#logical_expression" class=HREF><i>logical_expression</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>:</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#logical_expression" class=HREF><i>logical_expression</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="logical_expression" class=NAME><i>logical_expression</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#logical_term" class=HREF><i>logical_term</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><b>or</b><tt>&nbsp;</tt><a href="#logical_term" class=HREF><i>logical_term</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="logical_term" class=NAME><i>logical_term</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#logical_factor" class=HREF><i>logical_factor</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><b>and</b><tt>&nbsp;</tt><a href="#logical_factor" class=HREF><i>logical_factor</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="logical_factor" class=NAME><i>logical_factor</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><b>not</b><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#relation" class=HREF><i>relation</i></a>
+</p>
 <p><a name="relation" class=NAME><i>relation</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#arithmetic_expression" class=HREF><i>arithmetic_expression</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#relational_operator" class=HREF><i>relational_operator</i></a><tt>&nbsp;</tt><a href="#arithmetic_expression" class=HREF><i>arithmetic_expression</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="relational_operator" class=NAME><i>relational_operator</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green>"</font><tt>&lt;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>&lt;=</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>&gt;</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>&gt;=</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>==</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>&lt;&gt;</tt><font color=green>"</font>
+</p>
 <p><a name="arithmetic_expression" class=NAME><i>arithmetic_expression</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#add_operator" class=HREF><i>add_operator</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#term" class=HREF><i>term</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#add_operator" class=HREF><i>add_operator</i></a><tt>&nbsp;</tt><a href="#term" class=HREF><i>term</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="add_operator" class=NAME><i>add_operator</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green>"</font><tt>+</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>-</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>.+</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>.-</tt><font color=green>"</font>
+</p>
 <p><a name="term" class=NAME><i>term</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#factor" class=HREF><i>factor</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><a href="#mul_operator" class=HREF><i>mul_operator</i></a><tt>&nbsp;</tt><a href="#factor" class=HREF><i>factor</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="mul_operator" class=NAME><i>mul_operator</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green>"</font><tt>*</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>/</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>.*</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>./</tt><font color=green>"</font>
+</p>
 <p><a name="factor" class=NAME><i>factor</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#primary" class=HREF><i>primary</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green size="+1">(</font><tt>&nbsp;</tt><font color=green>"</font><tt>^</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>.^</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">)</font><tt>&nbsp;</tt><a href="#primary" class=HREF><i>primary</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="primary" class=NAME><i>primary</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>UNSIGNED_NUMBER</i>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><i>STRING</i>
@@ -203,46 +265,63 @@ readability. The following typographic conventions are used:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>[</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#expression_list" class=HREF><i>expression_list</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>;</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#expression_list" class=HREF><i>expression_list</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><font color=green>"</font><tt>]</tt><font color=green>"</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><font color=green>"</font><tt>{</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#array_arguments" class=HREF><i>array_arguments</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>}</tt><font color=green>"</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>end</b>
+</p>
 <p><a name="type_specifier" class=NAME><i>type_specifier</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>.</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><a href="#name" class=HREF><i>name</i></a>
+</p>
 <p><a name="name" class=NAME><i>name</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>.</tt><font color=green>"</font><tt>&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="component_reference" class=NAME><i>component_reference</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>.</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#array_subscripts" class=HREF><i>array_subscripts</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>.</tt><font color=green>"</font><tt>&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#array_subscripts" class=HREF><i>array_subscripts</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="function_call_args" class=NAME><i>function_call_args</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green>"</font><tt>(</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#function_arguments" class=HREF><i>function_arguments</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green>"</font><tt>)</tt><font color=green>"</font>
+</p>
 <p><a name="function_arguments" class=NAME><i>function_arguments</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#function_arguments_non_first" class=HREF><i>function_arguments_non_first</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>for</b><tt>&nbsp;</tt><a href="#for_indices" class=HREF><i>for_indices</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
-<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#function_partial_application" class=HREF><i>function_partial_application</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#function_arguments_non_first" class=HREF><i>function_arguments_non_first</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>function</b><tt>&nbsp;</tt><a href="#name" class=HREF><i>name</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>(</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#named_arguments" class=HREF><i>named_arguments</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green>"</font><tt>)</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#function_arguments_non_first" class=HREF><i>function_arguments_non_first</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#named_arguments" class=HREF><i>named_arguments</i></a>
+</p>
 <p><a name="function_arguments_non_first" class=NAME><i>function_arguments_non_first</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#function_argument" class=HREF><i>function_argument</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#function_arguments_non_first" class=HREF><i>function_arguments_non_first</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#named_arguments" class=HREF><i>named_arguments</i></a>
+</p>
 <p><a name="array_arguments" class=NAME><i>array_arguments</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#array_arguments_non_first" class=HREF><i>array_arguments_non_first</i></a><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><b>for</b><tt>&nbsp;</tt><a href="#for_indices" class=HREF><i>for_indices</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="array_arguments_non_first" class=NAME><i>array_arguments_non_first</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#array_arguments_non_first" class=HREF><i>array_arguments_non_first</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="named_arguments" class=NAME><i>named_arguments</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#named_argument" class=HREF><i>named_argument</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#named_arguments" class=HREF><i>named_arguments</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="named_argument" class=NAME><i>named_argument</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><i>IDENT</i><tt>&nbsp;</tt><font color=green>"</font><tt>=</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#function_argument" class=HREF><i>function_argument</i></a>
+</p>
 <p><a name="function_argument" class=NAME><i>function_argument</i></a>:
-<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#function_partial_application" class=HREF><i>function_partial_application</i></a>
+<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>function</b><tt>&nbsp;</tt><a href="#name" class=HREF><i>name</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>(</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#named_arguments" class=HREF><i>named_arguments</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green>"</font><tt>)</tt><font color=green>"</font>
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a>
-<p><a name="function_partial_application" class=NAME><i>function_partial_application</i></a>:
-<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>function</b><tt>&nbsp;</tt><a href="#type_specifier" class=HREF><i>type_specifier</i></a><tt>&nbsp;</tt><font color=green>"</font><tt>(</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#named_arguments" class=HREF><i>named_arguments</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green>"</font><tt>)</tt><font color=green>"</font>
+</p>
 <p><a name="output_expression_list" class=NAME><i>output_expression_list</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="expression_list" class=NAME><i>expression_list</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font>
+</p>
 <p><a name="array_subscripts" class=NAME><i>array_subscripts</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green>"</font><tt>[</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#subscript" class=HREF><i>subscript</i></a><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>,</tt><font color=green>"</font><tt>&nbsp;</tt><a href="#subscript" class=HREF><i>subscript</i></a><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><font color=green>"</font><tt>]</tt><font color=green>"</font>
+</p>
 <p><a name="subscript" class=NAME><i>subscript</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green>"</font><tt>:</tt><font color=green>"</font><tt>&nbsp;</tt><font color=green size="+1">|</font><tt>&nbsp;</tt><a href="#expression" class=HREF><i>expression</i></a>
+</p>
 <p><a name="comment" class=NAME><i>comment</i></a>:
-<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#string_comment" class=HREF><i>string_comment</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#annotation" class=HREF><i>annotation</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+<br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><a href="#string_comment" class=HREF><i>string_comment</i></a><tt>&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><a href="#annotation_comment" class=HREF><i>annotation_comment</i></a><tt>&nbsp;</tt><font color=green size="+1">]</font>
+</p>
 <p><a name="string_comment" class=NAME><i>string_comment</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><font color=green size="+1">[</font><tt>&nbsp;</tt><i>STRING</i><tt>&nbsp;</tt><font color=green size="+1">{</font><tt>&nbsp;</tt><font color=green>"</font><tt>+</tt><font color=green>"</font><tt>&nbsp;</tt><i>STRING</i><tt>&nbsp;</tt><font color=green size="+1">}</font><tt>&nbsp;</tt><font color=green size="+1">]</font>
-<p><a name="annotation" class=NAME><i>annotation</i></a>:
+</p>
+<p><a name="annotation_comment" class=NAME><i>annotation_comment</i></a>:
 <br><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt><b>annotation</b><tt>&nbsp;</tt><a href="#class_modification" class=HREF><i>class_modification</i></a>
+</p>
 </body></html>


### PR DESCRIPTION
Changed `annotation` to `annotation_comment`. Generated closing `</p>` tags. Should be up to date with the official 3.4 grammar now. Issue https://github.com/modelica/ModelicaStandardLibrary/issues/2820.